### PR TITLE
Fix unavatar URL

### DIFF
--- a/components/Blog.vue
+++ b/components/Blog.vue
@@ -84,7 +84,7 @@ export default {
     const url = new URL(this.blog.url);
     const domain = url.host;
     this.path = domain + url.pathname.replace(/\/$/, '');
-    const website = `https://unavatar.now.sh/${domain}`;
+    const website = `https://unavatar.io/${domain}`;
     this.favIcon = `https://images.weserv.nl/?url=${website}&w=100&l=9&af&il&n=-1`;
   }
 }


### PR DESCRIPTION
## Context
The URL [unavatar.now.sh](https://unavatar.now.sh) is broken and the good one is [unavatar.io](https://unavatar.io) which leads newly added blogs to not having an icon.

<img width="894" alt="Screenshot 2022-12-21 at 18 16 27" src="https://user-images.githubusercontent.com/16793854/208965777-63e81948-cdf5-43f8-8b5f-4c1247c1077e.png">

