### PR TITLE
Replace Rushflow.io with Deckrun.com

### DIFF
--- a/data.js
+++ b/data.js
@@ -4206,10 +4206,10 @@ module.exports = [
     ],
   },
   {
-    name: "Rushflow",
-    description: "Articles about DevOps written by Daniel Vigueras",
-    url: "https://rushflow.io",
-    twitter: "@rushflowio",
+    name: "Deckrun",
+    description: "DevOps and Infrastructure Articles",
+    url: "https://deckrun.com/blog",
+    twitter: "@deckruncom",
     tags: [
       "DevOps",
       "Command Line",


### PR DESCRIPTION
Almost two years ago I sent a PR adding Rushflow.io to this repository: https://github.com/markodenic/awesome-tech-blogs/pull/339 

Now I've migrated Rushflow.io blog to Deckrun.com/blog
The website is redirected.

This PR updates the URL with the new blog URL.